### PR TITLE
Bumping version by a lot to replace the default ros trajectory msg

### DIFF
--- a/trajectory_msgs/package.xml
+++ b/trajectory_msgs/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>trajectory_msgs</name>
-  <version>1.12.5</version>
+  <version>11.12.5</version>
   <description>
     This package defines messages for defining robot trajectories. These messages are
     also the building blocks of most of the


### PR DESCRIPTION
This fixes an issue where `apt-get` does not install the correct version of `ros-kinetic-trajectory-msgs`. It should install the Miso one over the default ROS one.